### PR TITLE
feat(merge-loader): introduced ConfigMergedLoader

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
   "module": "index.js",
   "typings": "index.d.ts",
   "dependencies": {
-    "tslib": "^1.6.0",
-    "typescript-object-utils": "^0.2.3"
+    "@types/lodash": "^4.14.55",
+    "lodash": "^4.17.4",
+    "tslib": "^1.6.0"
   },
   "devDependencies": {
     "@angular/common": "~2.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "module": "index.js",
   "typings": "index.d.ts",
   "dependencies": {
-    "tslib": "^1.6.0"
+    "tslib": "^1.6.0",
+    "typescript-object-utils": "^0.2.3"
   },
   "devDependencies": {
     "@angular/common": "~2.4.0",

--- a/src/config.loader.ts
+++ b/src/config.loader.ts
@@ -3,7 +3,11 @@ import { Http } from '@angular/http';
 
 // libs
 import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/reduce';
+import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/toPromise';
+import { Observable } from 'rxjs';
+import { mergeDeep } from 'typescript-object-utils';
 
 export abstract class ConfigLoader {
   abstract loadSettings(): any;
@@ -29,5 +33,26 @@ export class ConfigHttpLoader implements ConfigLoader {
       .toPromise()
       .then((settings: any) => settings)
       .catch(() => Promise.reject('Endpoint unreachable!'));
+  }
+}
+
+export class ConfigMergedLoader implements ConfigLoader {
+  constructor(private readonly http: Http,
+              private readonly paths: string[] = ['/config.json', '/config.local.json']) {
+  }
+
+  loadSettings(): any {
+    const errorIfEmpty: (source: Observable<any>) => Observable<any> = (source: Observable<any>) => {
+      return source.isEmpty()
+        .mergeMap((empty: boolean) => (empty) ? Observable.throw(new Error('empty')) : Observable.empty());
+    };
+    const jsons = Observable.onErrorResumeNext(this.paths.map(path => this.http.get(path)))
+      .map((res: any) => res.json())
+      .filter((x: any) => x !== null);
+    return jsons.merge(errorIfEmpty(jsons))
+      .reduce((x: any, y: any) => mergeDeep(x, y), {})
+      .toPromise()
+      .then((settings: any) => settings)
+      .catch(() => Promise.reject('Config was not loaded!'));
   }
 }

--- a/src/config.loader.ts
+++ b/src/config.loader.ts
@@ -5,6 +5,7 @@ import { Http } from '@angular/http';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/reduce';
 import 'rxjs/add/operator/mergeMap';
+import 'rxjs/add/operator/share';
 import 'rxjs/add/operator/toPromise';
 import { Observable } from 'rxjs';
 import * as _ from 'lodash';
@@ -55,7 +56,8 @@ export class ConfigMergedLoader implements ConfigLoader {
     };
     const jsons = Observable.onErrorResumeNext(this.paths.map(path => this.http.get(path)))
       .map((res: any) => res.json())
-      .filter((x: any) => x !== null);
+      .filter((x: any) => x !== null)
+      .share();
     return jsons.merge(errorIfEmpty(jsons))
       .reduce((x: any, y: any) => mergeWith(x, y), {})
       .toPromise()

--- a/tests/config.loader.spec.ts
+++ b/tests/config.loader.spec.ts
@@ -8,7 +8,7 @@ import { ConfigLoader, ConfigStaticLoader, ConfigHttpLoader, ConfigMergedLoader,
 import { testSettings, testModuleConfig } from './index.spec';
 
 // libs
-import { mergeDeep } from 'typescript-object-utils';
+import * as _ from 'lodash';
 
 const mockBackendResponse = (connection: MockConnection, response: any) => {
   connection.mockRespond(new Response(new ResponseOptions({body: response})));
@@ -161,21 +161,37 @@ describe('@nglibs/config:',
         const defaultRoutes = {
           '/config.json': {
             'setting1': 'value1',
-            'setting2': 'from config.json'
+            'setting2': 'from config.json',
+            'arr': [1, 2, 3],
+            'nested': {
+              'k1': 'v1',
+              'k2': 'v2 from config.json'
+            }
           },
           '/config.local.json': {
             'setting2': 'from config.local.json',
-            'setting3': 'value3'
+            'setting3': 'value3',
+            'arr': [4, 5]
           },
           '/env/test.json': {
-            'setting4': 'value4'
+            'setting4': 'value4',
+            'nested': {
+              'k2': 'v2 from env/test.json',
+              'k3': 'v3'
+            }
           }
         };
         const defaultMergedSettings = {
           'setting1': 'value1',
           'setting2': 'from config.local.json',
           'setting3': 'value3',
-          'setting4': 'value4'
+          'setting4': 'value4',
+          'arr': [4, 5],
+          'nested': {
+            'k1': 'v1',
+            'k2': 'v2 from env/test.json',
+            'k3': 'v3'
+          }
         };
 
         beforeEach(() => {
@@ -205,12 +221,18 @@ describe('@nglibs/config:',
           async(inject([MockBackend, ConfigService],
             (backend: MockBackend, config: ConfigService) => {
               // make '/config.local.json' unavailable
-              let routesCopy = mergeDeep(defaultRoutes, defaultRoutes);
+              let routesCopy = _.cloneDeep(defaultRoutes);
               delete routesCopy['/config.local.json'];
               const settings = {
                 'setting1': 'value1',
                 'setting2': 'from config.json',
-                'setting4': 'value4'
+                'setting4': 'value4',
+                'arr': [1, 2, 3],
+                'nested': {
+                  'k1': 'v1',
+                  'k2': 'v2 from env/test.json',
+                  'k3': 'v3'
+                }
               };
 
               // mock response

--- a/tests/config.loader.spec.ts
+++ b/tests/config.loader.spec.ts
@@ -4,8 +4,11 @@ import { Http, Response, ResponseOptions } from '@angular/http';
 import { MockBackend, MockConnection } from '@angular/http/testing';
 
 // module
-import { ConfigLoader, ConfigStaticLoader, ConfigHttpLoader, ConfigService } from '../index';
+import { ConfigLoader, ConfigStaticLoader, ConfigHttpLoader, ConfigMergedLoader, ConfigService } from '../index';
 import { testSettings, testModuleConfig } from './index.spec';
+
+// libs
+import { mergeDeep } from 'typescript-object-utils';
 
 const mockBackendResponse = (connection: MockConnection, response: any) => {
   connection.mockRespond(new Response(new ResponseOptions({body: response})));
@@ -13,6 +16,15 @@ const mockBackendResponse = (connection: MockConnection, response: any) => {
 
 const mockBackendError = (connection: MockConnection, error: string) => {
   connection.mockError(new Error(error));
+};
+
+const mockBackendRoute = (connection: MockConnection, routes: any) => {
+  const response = routes[connection.request.url];
+  if (typeof response !== undefined) {
+    mockBackendResponse(connection, response);
+  } else {
+    mockBackendError(connection, '404');
+  }
 };
 
 describe('@nglibs/config:',
@@ -63,6 +75,24 @@ describe('@nglibs/config:',
             expect(ConfigHttpLoader).toBeDefined();
             expect(config.loader).toBeDefined();
             expect(config.loader instanceof ConfigHttpLoader).toBeTruthy();
+          });
+
+        it('should be able to provide `ConfigMergedLoader`',
+          () => {
+            const configFactory = (http: Http) => new ConfigMergedLoader(http);
+
+            testModuleConfig({
+              provide: ConfigLoader,
+              useFactory: (configFactory),
+              deps: [Http]
+            });
+
+            const injector = getTestBed();
+            const config = injector.get(ConfigService);
+
+            expect(ConfigMergedLoader).toBeDefined();
+            expect(config.loader).toBeDefined();
+            expect(config.loader instanceof ConfigMergedLoader).toBeTruthy();
           });
 
         it('should be able to provide any `ConfigLoader`',
@@ -121,6 +151,88 @@ describe('@nglibs/config:',
               config.loader.loadSettings()
                 .catch((res: any) => {
                   expect(res).toEqual('Endpoint unreachable!');
+                });
+            })));
+      });
+
+    describe('ConfigMergedLoader',
+      () => {
+        const defaultPaths = ['/config.json', '/config.local.json', '/env/test.json'];
+        const defaultRoutes = {
+          '/config.json': {
+            'setting1': 'value1',
+            'setting2': 'from config.json'
+          },
+          '/config.local.json': {
+            'setting2': 'from config.local.json',
+            'setting3': 'value3'
+          },
+          '/env/test.json': {
+            'setting4': 'value4'
+          }
+        };
+        const defaultMergedSettings = {
+          'setting1': 'value1',
+          'setting2': 'from config.local.json',
+          'setting3': 'value3',
+          'setting4': 'value4'
+        };
+
+        beforeEach(() => {
+          const configFactory = (http: Http) => new ConfigMergedLoader(http, defaultPaths);
+
+          testModuleConfig({
+            provide: ConfigLoader,
+            useFactory: (configFactory),
+            deps: [Http]
+          });
+        });
+
+        it('should be able to retrieve and merge settings from the specified `paths`',
+          async(inject([MockBackend, ConfigService],
+            (backend: MockBackend, config: ConfigService) => {
+              // mock response
+              backend.connections.subscribe((c: MockConnection) => mockBackendRoute(c, defaultRoutes));
+
+              config.loader.loadSettings()
+                .then((res: any) => {
+                  expect(res).toEqual(defaultMergedSettings);
+                })
+                .catch(() => fail('unreached'));
+            })));
+
+        it('should allow some of files in `paths` to be unavailable',
+          async(inject([MockBackend, ConfigService],
+            (backend: MockBackend, config: ConfigService) => {
+              // make '/config.local.json' unavailable
+              let routesCopy = mergeDeep(defaultRoutes, defaultRoutes);
+              delete routesCopy['/config.local.json'];
+              const settings = {
+                'setting1': 'value1',
+                'setting2': 'from config.json',
+                'setting4': 'value4'
+              };
+
+              // mock response
+              backend.connections.subscribe((c: MockConnection) => mockBackendRoute(c, routesCopy));
+
+              config.loader.loadSettings()
+                .then((res: any) => {
+                  expect(res).toEqual(settings);
+                })
+                .catch(() => fail('unreached'));
+            })));
+
+        it('should throw if all files in `paths` were unavailable',
+          async(inject([MockBackend, ConfigService],
+            (backend: MockBackend, config: ConfigService) => {
+              // mock response
+              backend.connections.subscribe((c: MockConnection) => mockBackendRoute(c, {}));
+
+              config.loader.loadSettings()
+                .then(() => fail('unreached'))
+                .catch((res: any) => {
+                  expect(res).toEqual('Config was not loaded!');
                 });
             })));
       });


### PR DESCRIPTION
The idea was borrowed from the [config](https://github.com/railsconfig/config) ruby gem.

We usually have different versions of config for different environments or for different people. With `ConfigMergedLoader`, everyone can setup a localized config (a.k.a. `config.local.json`) for their own use. Further more, `ConfigMergedLoader` is smart enough to ignore missed config files (but not all of them), so that we don't need to commit `config.local.json` to the VCS.