### PR TITLE
fix(packaging): Disable compiling library with ivy

### DIFF
--- a/tools/build/tsconfig.package.json
+++ b/tools/build/tsconfig.package.json
@@ -21,5 +21,8 @@
       "es2015",
       "dom"
     ]
+  }, 
+  "angularCompilerOptions": {
+    "enableIvy": false
   }
 }


### PR DESCRIPTION
** PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/fulls1z3/ngx-config/blob/master/CONTRIBUTING.md#commit
- [x ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)

** PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

** What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #163

There is a build error when compiling an application with this library: 
```
ERROR: Error during template compile of 'CoreModule'
  Function calls are not supported in decorators but 'ConfigModule' was called.
```

** What is the new behavior?
No build error. It is not recomended for libraries to be compiled with ivy yet.

Per the CLI: 
```
It is not recommended to publish Ivy libraries to NPM repositories.
Read more here: https://v9.angular.io/guide/ivy#maintaining-library-compatibility
```
** Does this PR introduce a breaking change?
```
[ ] Yes
[ x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

** Other information
